### PR TITLE
Try to upload release with tag based on date

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Generate release tag
         id: tag
-        run: echo "::set-output name=tag::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+        run: echo "::set-output name=tag::$(date -u +'%s')"
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
It seems that github actions is not happy about human friendly timestamps in tags, whatever..