### PR TITLE
Postgres prod

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -37,7 +37,7 @@ jobs:
             apt-get update -q -y
 
             # Install Python, fpm deps (ruby) and the kitchen sink required to build everything...
-            apt-get install -q -y git python3 python3-venv python3-dev build-essential libffi-dev libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev libgdbm-dev libc6-dev libbz2-dev rustc cargo squashfs-tools ruby-full jq
+            apt-get install -q -y git python3 python3-venv python3-dev build-essential libffi-dev libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev libgdbm-dev libc6-dev libbz2-dev rustc cargo squashfs-tools ruby-full jq libpq-dev postgresql postgresql-contrib
 
             # Install FPM
             gem install fpm
@@ -113,6 +113,9 @@ jobs:
               --depends python3 \
               --depends nginx \
               --depends libffi-dev \
+              --depends libpq-dev \
+              --depends postgresql \
+              --depends postgresql-contrib \
               --after-install ./postinstall.sh \
               .
 

--- a/hackman/settings.py
+++ b/hackman/settings.py
@@ -56,6 +56,8 @@ INSTALLED_APPS = (
 
 SITE_ID = 1
 
+FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"
+
 AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)
 
 MIDDLEWARE = [

--- a/hackman/views.py
+++ b/hackman/views.py
@@ -195,13 +195,17 @@ def account_actions(request: HttpRequest) -> HttpResponse:
 
     valid_until = payment_api.get_valid_until(user_id)
 
+    last_unpaired_card: bytes = r.get("rfid_last_unpaired")
+    if last_unpaired_card is None:
+        last_unpaired_card = b""
+
     return shortcuts.render(
         request,
         "account_actions.jinja2",
         context={
             "payment_form": forms.PaymentForm(year_month_choices=_get_month_choices()),
             "rfid_pair_form": forms.RfidCardPairForm(
-                initial={"card_id": r.get("rfid_last_unpaired")}
+                initial={"card_id": last_unpaired_card.decode()}
             ),
             "paid": paid,
             "valid_until": valid_until.strftime("%Y-%m") if valid_until else None,

--- a/poetry.lock
+++ b/poetry.lock
@@ -465,6 +465,14 @@ testing = ["pytest-benchmark", "pytest"]
 dev = ["tox", "pre-commit"]
 
 [[package]]
+name = "psycopg2"
+version = "2.9.3"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "py"
 version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -736,7 +744,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "330c6c24e95b7f69a35ea1dbc553588c976768378683514a82e2f63aa860e1c2"
+content-hash = "f88136ba8bd5f8dde8fb36fdbf0faf92c01b77b92f8c52234f35af2b4b181e85"
 
 [metadata.files]
 asgiref = [
@@ -1172,6 +1180,19 @@ platformdirs = [
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+psycopg2 = [
+    {file = "psycopg2-2.9.3-cp310-cp310-win32.whl", hash = "sha256:083707a696e5e1c330af2508d8fab36f9700b26621ccbcb538abe22e15485362"},
+    {file = "psycopg2-2.9.3-cp310-cp310-win_amd64.whl", hash = "sha256:d3ca6421b942f60c008f81a3541e8faf6865a28d5a9b48544b0ee4f40cac7fca"},
+    {file = "psycopg2-2.9.3-cp36-cp36m-win32.whl", hash = "sha256:9572e08b50aed176ef6d66f15a21d823bb6f6d23152d35e8451d7d2d18fdac56"},
+    {file = "psycopg2-2.9.3-cp36-cp36m-win_amd64.whl", hash = "sha256:a81e3866f99382dfe8c15a151f1ca5fde5815fde879348fe5a9884a7c092a305"},
+    {file = "psycopg2-2.9.3-cp37-cp37m-win32.whl", hash = "sha256:cb10d44e6694d763fa1078a26f7f6137d69f555a78ec85dc2ef716c37447e4b2"},
+    {file = "psycopg2-2.9.3-cp37-cp37m-win_amd64.whl", hash = "sha256:4295093a6ae3434d33ec6baab4ca5512a5082cc43c0505293087b8a46d108461"},
+    {file = "psycopg2-2.9.3-cp38-cp38-win32.whl", hash = "sha256:34b33e0162cfcaad151f249c2649fd1030010c16f4bbc40a604c1cb77173dcf7"},
+    {file = "psycopg2-2.9.3-cp38-cp38-win_amd64.whl", hash = "sha256:0762c27d018edbcb2d34d51596e4346c983bd27c330218c56c4dc25ef7e819bf"},
+    {file = "psycopg2-2.9.3-cp39-cp39-win32.whl", hash = "sha256:8cf3878353cc04b053822896bc4922b194792df9df2f1ad8da01fb3043602126"},
+    {file = "psycopg2-2.9.3-cp39-cp39-win_amd64.whl", hash = "sha256:06f32425949bd5fe8f625c49f17ebb9784e1e4fe928b7cce72edc36fb68e4c0c"},
+    {file = "psycopg2-2.9.3.tar.gz", hash = "sha256:8e841d1bf3434da985cc5ef13e6f75c8981ced601fd70cc6bf33351b91562981"},
 ]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ gevent = "^21.12.0"
 pyserial = "^3.5"
 "RPi.GPIO" = "^0.7.1"
 mote = "^0.0.4"
+psycopg2 = "^2.9.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> { } }:
 let
-  pythonEnv = pkgs.python3.withPackages(_: []);
+  pythonEnv = pkgs.python39.withPackages(_: []);
 in
 pkgs.mkShell {
   packages = [
@@ -8,6 +8,7 @@ pkgs.mkShell {
     pythonEnv
 
     pkgs.redis
+    pkgs.postgresql
 
     pkgs.fpm
   ];


### PR DESCRIPTION
This installs required dependencies to use postgresql in production since there has been issues with the database files going read-only which is _probably_ caused by some race in the systemd units.

The easiest fix is to just ignore these file system issues and use postgres which has the additional benefit of not having to take care to have every systemd unit but the web server be read only.

Note that the settings are _not_ updated to reflect the addition of postgres yet., that will be a follow-up PR once we've nailed down the settings on the actual pi.